### PR TITLE
Fix broken link to ksat.me in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Inspired by the above comment by [Brad Hodson](https://www.producthunt.com/@brad
 * [The Children's Illustrated Guide to Kubernetes](https://cdn.chrisshort.net/The-Illustrated-Childrens-Guide-to-Kubernetes.pdf) - Introducing Phippy, an intrepid little PHP app, and her journey to Kubernetes.
 * [WTF is The Blockchain?](https://hackernoon.com/wtf-is-the-blockchain-1da89ba19348) - The ultimate 3500-word guide in plain English to understand Blockchain
 * [Understanding Git](https://hackernoon.com/understanding-git-fcffd87c15a3) - Git is a powerful tool, but it has a reputation of baffling newcomers. It doesn't help that most people are simply thrown in at the deep end and expected to swim. With the right knowledge, anyone can master git. Once you start to understand it, the terminology will make more sense and you'll (eventually) learn to love it.
-* [A plain english introduction to CAP Theorem](http://ksat.me/a-plain-english-introduction-to-cap-theorem/) - You'll often hear about the CAP theorem which specifies some kind of an upper limit when designing distributed systems. This introductory tutorial explains the concept by comparing it with a real world situation.
+* [A plain english introduction to CAP Theorem](http://ksat.me/a-plain-english-introduction-to-cap-theorem) - You'll often hear about the CAP theorem which specifies some kind of an upper limit when designing distributed systems. This introductory tutorial explains the concept by comparing it with a real world situation.
 * [How to dance the OAuth: a step-by-step lesson](https://medium.freecodecamp.org/how-to-dance-the-oauth-a-step-by-step-lesson-fd2364d89742) - An easy guide for understanding the key concepts of OAuth 2.0
 
 ## Contributing


### PR DESCRIPTION
The link to "A plain english introduction to CAP Theorem" results in a 404 due to a stray slash at the end of the link. By removing the slash, the link works.